### PR TITLE
Refactoring Interpreter as an Iterator

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -122,6 +122,7 @@ fn b08_interpret_slow(b: &mut Bencher) {
 }
 
 #[bench]
+#[ignore]
 fn b08_interpret_slow_opt(b: &mut Bencher) {
     let program = precompile(SLOW_SOURCE.iter(), OptimizationLevel::Speed);
     b.iter(|| interpret(program.clone()));

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -122,7 +122,6 @@ fn b08_interpret_slow(b: &mut Bencher) {
 }
 
 #[bench]
-#[ignore]
 fn b08_interpret_slow_opt(b: &mut Bencher) {
     let program = precompile(SLOW_SOURCE.iter(), OptimizationLevel::Speed);
     b.iter(|| interpret(program.clone()));

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -37,7 +37,7 @@ impl std::io::Write for NullWrite {
 
 fn interpret(program: Vec<Instruction>) {
     let mut inp: &[u8] = &[];
-    Interpreter::from_streams(&mut inp, &mut NullWrite, &mut NullWrite).interpret(program);
+    Interpreter::new(&mut inp, &mut NullWrite).interpret(program);
 }
 
 #[bench]


### PR DESCRIPTION
Fixes #6 

Refactoring interpreter to implement Iterator. This allows us to separate debugging-specific code out into the executable where it belongs. 

**Discovered and fixed a major bug in the debugging output.**

- [x] Check profiling output and evaluate how to move forward based on speed difference
- [x] Update [brain-lang/brain-debug](https://github.com/brain-lang/brain-debug) to accept the new format and add something to the README about a minimum version
- [x] Make sure this bug gets fixed even if this PR is closed