### PR TITLE
Adding interpreter callback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,5 @@ script:
   - cargo test --verbose
   - cargo doc --verbose
 after_success:
-  - |
-      cargo coverage --verbose
-      bash <(curl -s https://codecov.io/bash)
-      ./travis-after-success.sh
+  - cargo coverage --verbose && bash <(curl -s https://codecov.io/bash)
+  - ./travis-after-success.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Tests! Lots of tests! The code is now nicely split up between modules too.
+- Heavy optimizations resulting in `examples/mandel.bf` going from 46.404s to
+  15.576s on @sunjay's machine.
 
 ### Fixed
 - Fixed a bug that was resulting in some cases of mismatched jump instructions
   not being reported as an error.
+- Realized that the output fields of `--debug` were absolutely incorrect. They
+  are now updated to reflect reality.
+  - The problem was that we were assuming the the previous instruction was one
+    less than the current one. However, based on how the interpreter actually
+    works, this is completely false. The variables being used in the debug
+    output should never have been reported that way. The new debug output is
+    accurate in that it reports the "next" instruction that will be processed.
+    We also now output the initial state of the interpreter so that a more
+    accurate picture of what is going on can be formed.
 
 ## [1.2.0] - 2017-04-19
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "brain-brainfuck"
 version = "1.2.0"
 dependencies = [
  "clap 2.23.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "colored 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -42,6 +43,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +58,11 @@ dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
@@ -105,7 +119,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
 "checksum clap 2.23.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf1114886d7cde2d6448517161d7db8d681a9a1c09f7d210f0b0864e48195f6"
+"checksum colored 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "28ac9262ecb0c06ced80088dad74d813458a909016b554fbf9199177acec697a"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ travis-ci = { repository = "brain-lang/brainfuck" }
 
 [dependencies]
 clap = "^2.0"
+colored = "^1.4"
 
 [dev-dependencies]
 lazy_static = "0.2"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -122,6 +122,7 @@ fn b08_interpret_slow(b: &mut Bencher) {
 }
 
 #[bench]
+#[ignore]
 fn b08_interpret_slow_opt(b: &mut Bencher) {
     let program = precompile(SLOW_SOURCE.iter(), OptimizationLevel::Speed);
     b.iter(|| interpret(program.clone()));

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -122,7 +122,6 @@ fn b08_interpret_slow(b: &mut Bencher) {
 }
 
 #[bench]
-#[ignore]
 fn b08_interpret_slow_opt(b: &mut Bencher) {
     let program = precompile(SLOW_SOURCE.iter(), OptimizationLevel::Speed);
     b.iter(|| interpret(program.clone()));

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -8,7 +8,7 @@ extern crate brainfuck;
 
 use test::Bencher;
 
-use brainfuck::{precompile, Interpreter, Instruction, OptimizationLevel};
+use brainfuck::{precompile, Instruction, OptimizationLevel};
 
 lazy_static! {
     // This program is trivial to run in both size and speed
@@ -37,7 +37,7 @@ impl std::io::Write for NullWrite {
 
 fn interpret(program: Vec<Instruction>) {
     let mut inp: &[u8] = &[];
-    Interpreter::from_streams(&mut inp, &mut NullWrite, &mut NullWrite).interpret(program);
+    brainfuck::interpret(&mut inp, NullWrite, program, |_| {});
 }
 
 #[bench]

--- a/src/bin/brainfuck.rs
+++ b/src/bin/brainfuck.rs
@@ -2,6 +2,7 @@
 
 #[macro_use]
 extern crate clap;
+extern crate colored;
 
 extern crate brainfuck;
 
@@ -12,9 +13,10 @@ use std::io::prelude::*;
 use std::thread;
 use std::time::Duration;
 
+use colored::*;
 use clap::{Arg, App};
 
-use brainfuck::{precompile, interpret};
+use brainfuck::{precompile, interpret, InterpreterState, DebugFormat, Instruction, OptimizationLevel};
 
 macro_rules! exit_with_error(
     ($($arg:tt)*) => { {
@@ -42,6 +44,13 @@ fn main() {
             .long("debug")
             .help("Enables debug mode which outputs debugging information to stderr")
         )
+        .arg(Arg::with_name("debug-format")
+            .long("debug-format")
+            .value_name("format")
+            .default_value("text")
+            .possible_values(&["text", "json"])
+            .help("The format of the debugging output")
+        )
         .arg(Arg::with_name("optimize")
             .short("O")
             .long("optimize")
@@ -65,6 +74,8 @@ fn main() {
     }
 
     let debug_mode = args.is_present("debug-enabled");
+    // We can call unwrap() because the validation is already done by clap
+    let debug_format = args.value_of("debug-format").unwrap().parse().unwrap();
 
     let delay: u64 = if let Some(delay_str) = args.value_of("delay") {
         delay_str.parse().unwrap_or_else(|e: std::num::ParseIntError| exit_with_error!("Invalid delay: {}", e))
@@ -83,29 +94,22 @@ fn main() {
     f.read_to_end(&mut bytes).expect("Fatal: Could not read source file");
     let program = precompile(bytes.iter(), opt);
 
-    // Based on debug_mode and delay, this will run one of three functions
+    // Based on debug_mode and delay, this will run one of several functions
     // If there is no delay and debug mode is off, performance is prioritized and the interpreter
     // should run at top speed
     let input = io::stdin();
     let output = io::stdout();
     if debug_mode {
-        interpret(
-            input,
-            output,
-            program,
-            |state| {
-                writeln!(
-                    &mut io::stderr(),
-                    "{{\"nextInstructionIndex\": {}, \"lastInstruction\": {}, \"currentPointer\": {}, \"memory\": \"{}\"}}",
-                    state.next_instruction,
-                    state.last_instruction.map_or_else(|| "null".to_owned(), |instr| format!("\"{}\"", instr.to_string())),
-                    state.current_pointer,
-                    state.memory.iter().fold(String::new(), |acc, v| format!("{} {}", acc, v))
-                ).expect("failed printing to stderr");
+        match debug_format {
+            DebugFormat::Text => {
+                interpret(input, output, program, |state| format_human_readable(state, delay, match opt {
+                    OptimizationLevel::Off => 1,
+                    OptimizationLevel::Speed => 4,
+                }));
+            },
 
-                thread::sleep(Duration::from_millis(delay));
-            }
-        );
+            DebugFormat::Json => interpret(input, output, program, |state| format_json(state, delay)),
+        }
     }
     // Need this condition because delay can be active without debug_mode
     else if delay > 0 {
@@ -114,4 +118,58 @@ fn main() {
     else {
         interpret(input, output, program, |_| {});
     }
+}
+
+#[inline]
+fn format_human_readable(state: InterpreterState, delay: u64, instruction_width: usize) {
+    use Instruction::*;
+
+    let pointer = state.current_pointer;
+
+    let current_instruction = format!("#{:<3}", state.current_instruction);
+
+    let instr = state.instruction;
+    let instruction = match instr {
+        Right(..) | Left(..) => instr.to_string().on_cyan(),
+        Increment(..) | Decrement(..) => instr.to_string().on_green(),
+        Write => instr.to_string().on_purple(),
+        Read => instr.to_string().on_yellow(),
+        JumpForwardIfZero { .. } | JumpBackwardUnlessZero { .. } => {
+            instr.to_string().on_blue()
+        },
+    }.bold();
+
+    let memory = state.memory.iter().enumerate().fold(String::new(), |acc, (i, c)| {
+        let mut cell = c.to_string().normal();
+        if i == pointer {
+            cell = cell.blue().bold();
+        }
+        format!("{} {:>3}", acc, cell)
+    });
+
+    writeln!(
+        &mut io::stderr(),
+        "{} {:instruction_width$} {}",
+        current_instruction.normal(),
+        instruction,
+        memory,
+
+        instruction_width = instruction_width,
+    ).expect("failed to write debug output to stderr");
+
+    thread::sleep(Duration::from_millis(delay));
+}
+
+#[inline]
+fn format_json(state: InterpreterState, delay: u64) {
+    writeln!(
+        &mut io::stderr(),
+        "{{\"currentInstructionIndex\": {}, \"instruction\": \"{}\", \"currentPointer\": {}, \"memory\": \"{}\"}}",
+        state.current_instruction,
+        state.instruction,
+        state.current_pointer,
+        state.memory.iter().fold(String::new(), |acc, v| format!("{} {}", acc, v))
+    ).expect("failed printing to stderr");
+
+    thread::sleep(Duration::from_millis(delay));
 }

--- a/src/debug_format.rs
+++ b/src/debug_format.rs
@@ -1,0 +1,36 @@
+use std::str::FromStr;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum DebugFormat {
+    /// Human readable text format
+    Text,
+    /// Machine readable JSON format
+    Json,
+}
+
+impl FromStr for DebugFormat {
+    type Err = ();
+
+    fn from_str(val: &str) -> Result<Self, Self::Err> {
+        match val {
+            "text" => Ok(DebugFormat::Text),
+            "json" => Ok(DebugFormat::Json),
+            _ => Err(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_str() {
+        let opt: DebugFormat = "text".parse().unwrap();
+        assert_eq!(opt, DebugFormat::Text);
+        let opt: DebugFormat = "json".parse().unwrap();
+        assert_eq!(opt, DebugFormat::Json);
+
+        assert!("foo".parse::<DebugFormat>().is_err());
+    }
+}

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::iter::repeat;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Instruction {
@@ -31,17 +30,22 @@ pub enum Instruction {
 
 impl fmt::Display for Instruction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", match *self {
-            Instruction::Right(n) => repeat(">").take(n).collect(),
-            Instruction::Left(n) => repeat("<").take(n).collect(),
-            Instruction::Increment(n) => repeat("+").take(n).collect(),
-            Instruction::Decrement(n) => repeat("-").take(n).collect(),
+        f.write_str(match *self {
+            Instruction::Right(n) => format_instruction(">", n),
+            Instruction::Left(n) => format_instruction("<", n),
+            Instruction::Increment(n) => format_instruction("+", n),
+            Instruction::Decrement(n) => format_instruction("-", n),
             Instruction::Write => ".".to_owned(),
             Instruction::Read => ",".to_owned(),
             Instruction::JumpForwardIfZero { .. } => "[".to_owned(),
             Instruction::JumpBackwardUnlessZero { .. } => "]".to_owned(),
-        })
+        }.as_ref())
     }
+}
+
+#[inline]
+fn format_instruction(instr: &str, n: usize) -> String {
+    format!("{}{}", instr, if n > 1 {format!("{}", n)} else {"".to_owned()})
 }
 
 #[cfg(test)]
@@ -51,20 +55,20 @@ mod tests {
     #[test]
     fn display() {
         assert_eq!(Instruction::Right(1).to_string(), ">");
-        assert_eq!(Instruction::Right(2).to_string(), ">>");
-        assert_eq!(Instruction::Right(5).to_string(), ">>>>>");
+        assert_eq!(Instruction::Right(2).to_string(), ">2");
+        assert_eq!(Instruction::Right(5).to_string(), ">5");
 
         assert_eq!(Instruction::Left(1).to_string(), "<");
-        assert_eq!(Instruction::Left(2).to_string(), "<<");
-        assert_eq!(Instruction::Left(5).to_string(), "<<<<<");
+        assert_eq!(Instruction::Left(2).to_string(), "<2");
+        assert_eq!(Instruction::Left(5).to_string(), "<5");
 
         assert_eq!(Instruction::Increment(1).to_string(), "+");
-        assert_eq!(Instruction::Increment(2).to_string(), "++");
-        assert_eq!(Instruction::Increment(5).to_string(), "+++++");
+        assert_eq!(Instruction::Increment(2).to_string(), "+2");
+        assert_eq!(Instruction::Increment(5).to_string(), "+5");
 
         assert_eq!(Instruction::Decrement(1).to_string(), "-");
-        assert_eq!(Instruction::Decrement(2).to_string(), "--");
-        assert_eq!(Instruction::Decrement(5).to_string(), "-----");
+        assert_eq!(Instruction::Decrement(2).to_string(), "-2");
+        assert_eq!(Instruction::Decrement(5).to_string(), "-5");
 
         assert_eq!(Instruction::Write.to_string(), ".");
         assert_eq!(Instruction::Read.to_string(), ",");

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -30,7 +30,7 @@ pub fn interpret<I, O, F>(mut inp: I, mut out: O, mut program: Vec<Instruction>,
     let mut next_instruction: usize = 0;
 
     callback(InterpreterState {
-        next_instruction: next_instruction,
+        next_instruction,
         last_instruction: None,
         current_pointer: pointer,
         memory: &buffer,
@@ -86,7 +86,7 @@ pub fn interpret<I, O, F>(mut inp: I, mut out: O, mut program: Vec<Instruction>,
         }
 
         callback(InterpreterState {
-            next_instruction: next_instruction,
+            next_instruction,
             last_instruction: Some(instr),
             current_pointer: pointer,
             memory: &buffer,
@@ -379,12 +379,7 @@ mod tests {
             (6, Some(JumpBackwardUnlessZero {matching: 4}), 0, vec![0, 0, 0, 0, 0, 0].into()),
         ];
         let mut states: VecDeque<_> = states.iter().map(|&(next_instruction, last_instruction, current_pointer, ref memory)| {
-            InterpreterState {
-                next_instruction: next_instruction,
-                last_instruction: last_instruction,
-                current_pointer: current_pointer,
-                memory: memory,
-            }
+            InterpreterState {next_instruction, last_instruction, current_pointer, memory}
         }).collect();
 
         interpret(&mut inp, &mut out, program, |state| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,13 @@ mod instruction;
 mod optlevel;
 mod precompiler;
 mod interpreter;
+mod debug_format;
 
 pub use instruction::*;
 pub use optlevel::*;
 pub use precompiler::*;
 pub use interpreter::*;
+pub use debug_format::*;
 
 // We typically don't expect to see more than this many levels of nested jumps
 // based on an analysis of some brainfuck programs

--- a/src/optlevel.rs
+++ b/src/optlevel.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum OptimizationLevel {
     // Do not optimize
     Off,

--- a/travis-after-success.sh
+++ b/travis-after-success.sh
@@ -6,6 +6,8 @@ set -x
 if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" != "master" ] && [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
     REMOTE_URL="$(git config --get remote.origin.url)";
     cargo install cargo-benchcmp;
+    env | grep "TRAVIS_"
+
     # Clone the repository fresh..for some reason checking out master fails
     # from a normal PR build's provided directory
     cd ${TRAVIS_BUILD_DIR}/.. && \

--- a/travis-after-success.sh
+++ b/travis-after-success.sh
@@ -4,20 +4,43 @@ set -e
 set -x
 
 if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" != "master" ] && [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
-    REMOTE_URL="$(git config --get remote.origin.url)";
-    cargo install cargo-benchcmp;
-    env | grep "TRAVIS_"
+    REMOTE_URL="$(git config --get remote.origin.url)"
+    cargo install cargo-benchcmp
 
     # Clone the repository fresh..for some reason checking out master fails
     # from a normal PR build's provided directory
-    cd ${TRAVIS_BUILD_DIR}/.. && \
-    git clone ${REMOTE_URL} "${TRAVIS_REPO_SLUG}-bench" && \
-    cd  "${TRAVIS_REPO_SLUG}-bench" && \
+    cd ${TRAVIS_BUILD_DIR}/..
+    git clone ${REMOTE_URL} "${TRAVIS_REPO_SLUG}-bench"
+    cd  "${TRAVIS_REPO_SLUG}-bench"
+
+    # The Travis environment variables behave like so:
+    # TRAVIS_BRANCH
+    #   - if PR build, this is the pr base branch
+    #   - if push build, this is the branch that was pushed
+    # TRAVIS_PULL_REQUEST_BRANCH
+    #   - if PR build, this is the "target" of the pr, i.e. not the base branch
+    #   - if push build, this is blank
+    #
+    # Example:
+    # You open a PR with base `master`, and PR branch `foo`
+    # During a PR build:
+    #     TRAVIS_BRANCH=master
+    #     TRAVIS_PULL_REQUEST_BRANCH=foo
+    # During a push build:
+    #     TRAVIS_BRANCH=foo
+    #     TRAVIS_PULL_REQUEST_BRANCH=
+
     # Bench the pull request base or master
-    git checkout -f "${TRAVIS_PULL_REQUEST_BRANCH:-master}" && \
-    cargo bench --verbose | tee previous-benchmark && \
+    if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
+      git checkout -f "$TRAVIS_BRANCH"
+    else # this is a push build
+      # This could be replaced with something better like asking git which
+      # branch is the base of $TRAVIS_BRANCH
+      git checkout -f master
+    fi
+    cargo bench --verbose | tee previous-benchmark
     # Bench the current commit that was pushed
-    git checkout -f ${TRAVIS_BRANCH} && \
-    cargo bench --verbose | tee current-benchmark && \
-    cargo benchcmp previous-benchmark current-benchmark;
+    git checkout -f "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
+    cargo bench --verbose | tee current-benchmark
+    cargo benchcmp previous-benchmark current-benchmark
 fi


### PR DESCRIPTION
Fixes #6

This PR adds a callback to the interpreter and refactors it back into a simple function. The entire struct with one method was completely unnecessary and the iterator approach in #15 slowed everything down a lot.

Hopefully this approach fixes things so everything is faster and still elegant.

This is an important change because it separates the debug and delay logic from the interpreter and makes everything testable.

----

**Discovered and fixed a major bug in the debugging output.**

- [x] Check profiling output and evaluate how to move forward based on speed difference
- [x] Update [brain-lang/brain-debug](https://github.com/brain-lang/brain-debug) to accept the new format and add something to the README about a minimum version (see https://github.com/brain-lang/brain-debug/commit/df8de307f9f8fe3a50ccd29ebca6f5cbba7e63c4)
- [x] Make sure this bug gets fixed even if this PR is closed